### PR TITLE
Closes #2, adding tests and a custom Fixie convention that supports parameterized tests.

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -39,6 +39,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Domain\AudioBook.cs" />
+    <Compile Include="Domain\Duration.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Core/Domain/AudioBook.cs
+++ b/src/Core/Domain/AudioBook.cs
@@ -1,0 +1,30 @@
+﻿namespace Core.Domain
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public class AudioBook
+    {
+        public AudioBook()
+        {
+            Chapters = new List<AudioChapter>();
+        }
+
+        public IList<AudioChapter> Chapters { get; private set; }
+
+        public Duration GetDuration()
+        {
+            return new Duration(Chapters.Sum(x => x.Duration.TotalSeconds));
+        }
+    }
+
+    public class AudioChapter
+    {
+        public AudioChapter(Duration duration)
+        {
+            Duration = duration;
+        }
+
+        public Duration Duration { get; private set; }
+    }
+}

--- a/src/Core/Domain/AudioBook.cs
+++ b/src/Core/Domain/AudioBook.cs
@@ -14,7 +14,7 @@
 
         public Duration GetDuration()
         {
-            return new Duration(Chapters.Sum(x => x.Duration));
+            return Chapters.Sum(x => x.Duration);
         }
     }
 

--- a/src/Core/Domain/AudioBook.cs
+++ b/src/Core/Domain/AudioBook.cs
@@ -14,7 +14,7 @@
 
         public Duration GetDuration()
         {
-            return new Duration(Chapters.Sum(x => x.Duration.TotalSeconds));
+            return new Duration(Chapters.Sum(x => x.Duration));
         }
     }
 

--- a/src/Core/Domain/Duration.cs
+++ b/src/Core/Domain/Duration.cs
@@ -17,7 +17,7 @@
 
         public string Display
         {
-            get { return string.Format("{0}:{1}", Minutes, Seconds); }
+            get { return string.Format("{0:0}:{1:00}", Minutes, Seconds); }
         }
 
         public static Duration operator +(Duration a, Duration b)

--- a/src/Core/Domain/Duration.cs
+++ b/src/Core/Domain/Duration.cs
@@ -25,5 +25,10 @@
         {
             return new Duration(a.TotalSeconds + b.TotalSeconds);
         }
+
+        public static implicit operator int(Duration duration)
+        {
+            return duration.TotalSeconds;
+        }
     }
 }

--- a/src/Core/Domain/Duration.cs
+++ b/src/Core/Domain/Duration.cs
@@ -30,5 +30,10 @@
         {
             return duration.TotalSeconds;
         }
+
+        public static implicit operator Duration(int totalSeconds)
+        {
+            return new Duration(totalSeconds);
+        }
     }
 }

--- a/src/Core/Domain/Duration.cs
+++ b/src/Core/Domain/Duration.cs
@@ -5,7 +5,10 @@
         public Duration(int totalSeconds)
         {
             TotalSeconds = totalSeconds;
-            //math to split seconds into minutes and seconds
+
+            const int secondsPerMinute = 60;
+            Minutes = totalSeconds/secondsPerMinute;
+            Seconds = totalSeconds%secondsPerMinute;
         }
 
         public int Minutes { get; private set; }

--- a/src/Core/Domain/Duration.cs
+++ b/src/Core/Domain/Duration.cs
@@ -2,22 +2,23 @@
 {
     public class Duration
     {
+        private readonly int _minutes;
+        private readonly int _seconds;
+
         public Duration(int totalSeconds)
         {
             TotalSeconds = totalSeconds;
 
             const int secondsPerMinute = 60;
-            Minutes = totalSeconds/secondsPerMinute;
-            Seconds = totalSeconds%secondsPerMinute;
+            _minutes = totalSeconds/secondsPerMinute;
+            _seconds = totalSeconds%secondsPerMinute;
         }
 
-        public int Minutes { get; private set; }
-        public int Seconds { get; private set; }
         public int TotalSeconds { get; private set; }
 
         public string Display
         {
-            get { return string.Format("{0:0}:{1:00}", Minutes, Seconds); }
+            get { return string.Format("{0:0}:{1:00}", _minutes, _seconds); }
         }
 
         public static Duration operator +(Duration a, Duration b)

--- a/src/Core/Domain/Duration.cs
+++ b/src/Core/Domain/Duration.cs
@@ -1,0 +1,25 @@
+﻿namespace Core.Domain
+{
+    public class Duration
+    {
+        public Duration(int totalSeconds)
+        {
+            TotalSeconds = totalSeconds;
+            //math to split seconds into minutes and seconds
+        }
+
+        public int Minutes { get; private set; }
+        public int Seconds { get; private set; }
+        public int TotalSeconds { get; private set; }
+
+        public string Display
+        {
+            get { return string.Format("{0}:{1}", Minutes, Seconds); }
+        }
+
+        public static Duration operator +(Duration a, Duration b)
+        {
+            return new Duration(a.TotalSeconds + b.TotalSeconds);
+        }
+    }
+}

--- a/src/Tests/CustomConvention.cs
+++ b/src/Tests/CustomConvention.cs
@@ -1,0 +1,34 @@
+﻿namespace Tests
+{
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using Fixie;
+
+    public class CustomConvention : Convention
+    {
+        public CustomConvention()
+        {
+            Classes
+                .NameEndsWith("Tests");
+
+            Methods
+                .Where(method => method.IsVoid());
+
+            Parameters
+                .Add(method => method.GetCustomAttributes<InputAttribute>(true)
+                    .Select(input => input.Parameters));
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class InputAttribute : Attribute
+    {
+        public InputAttribute(params object[] parameters)
+        {
+            Parameters = parameters;
+        }
+
+        public object[] Parameters { get; private set; }
+    }
+}

--- a/src/Tests/Domain/AudioBookTests.cs
+++ b/src/Tests/Domain/AudioBookTests.cs
@@ -1,0 +1,18 @@
+﻿namespace Tests.Domain
+{
+    using Core.Domain;
+    using Should;
+
+    public class AudioBookTests
+    {
+        public void Should_sum_chapter_durations_to_find_book_duration()
+        {
+            var book = new AudioBook();
+            book.Chapters.Add(new AudioChapter(new Duration(60)));
+            book.Chapters.Add(new AudioChapter(new Duration(55)));
+            book.Chapters.Add(new AudioChapter(new Duration(0)));
+            book.Chapters.Add(new AudioChapter(new Duration(63)));
+            book.GetDuration().Display.ShouldEqual("2:58");
+        }
+    }
+}

--- a/src/Tests/Domain/DurationTests.cs
+++ b/src/Tests/Domain/DurationTests.cs
@@ -25,5 +25,13 @@
             var durationB = new Duration(totalSecondsB);
             (durationA + durationB).Display.ShouldEqual(expectedSumDisplay);
         }
+
+        public void Should_add_durations()
+        {
+            var durationA = new Duration(30);
+            var durationB = new Duration(45);
+            int sum = durationA + durationB;
+            sum.ShouldEqual(30 + 45);
+        }
     }
 }

--- a/src/Tests/Domain/DurationTests.cs
+++ b/src/Tests/Domain/DurationTests.cs
@@ -14,5 +14,16 @@
             var duration = new Duration(totalSeconds);
             duration.Display.ShouldEqual(expectedDisplay);
         }
+
+        [Input(1, 1, "0:02")]
+        [Input(0, 0, "0:00")]
+        [Input(65, 63, "2:08")]
+        [Input(65, 0, "1:05")]
+        public void Should_sum_durations(int totalSecondsA, int totalSecondsB, string expectedSumDisplay)
+        {
+            var durationA = new Duration(totalSecondsA);
+            var durationB = new Duration(totalSecondsB);
+            (durationA + durationB).Display.ShouldEqual(expectedSumDisplay);
+        }
     }
 }

--- a/src/Tests/Domain/DurationTests.cs
+++ b/src/Tests/Domain/DurationTests.cs
@@ -15,5 +15,15 @@
             duration.Minutes.ShouldEqual(expectedMinutes);
             duration.Seconds.ShouldEqual(expectedSeconds);
         }
+
+        [Input(60, "1:00")]
+        [Input(61, "1:01")]
+        [Input(45, "0:45")]
+        [Input(0, "0:00")]
+        public void Should_display_duration_as_formatted_minutes_and_seconds(int totalSeconds, string expectedDisplay)
+        {
+            var duration = new Duration(totalSeconds);
+            duration.Display.ShouldEqual(expectedDisplay);
+        }
     }
 }

--- a/src/Tests/Domain/DurationTests.cs
+++ b/src/Tests/Domain/DurationTests.cs
@@ -1,0 +1,27 @@
+﻿namespace Tests.Domain
+{
+    using Core.Domain;
+    using Should;
+
+    public class DurationTests
+    {
+        public void Should_split_seconds_into_minutes_and_seconds()
+        {
+            var duration = new Duration(60);
+            duration.Minutes.ShouldEqual(1);
+            duration.Seconds.ShouldEqual(0);
+
+            var minutesAndSeconds = new Duration(61);
+            minutesAndSeconds.Minutes.ShouldEqual(1);
+            minutesAndSeconds.Seconds.ShouldEqual(1);
+
+            var lessThanAMinute = new Duration(45);
+            lessThanAMinute.Minutes.ShouldEqual(0);
+            lessThanAMinute.Seconds.ShouldEqual(45);
+
+            var zero = new Duration(0);
+            zero.Minutes.ShouldEqual(0);
+            zero.Seconds.ShouldEqual(0);
+        }
+    }
+}

--- a/src/Tests/Domain/DurationTests.cs
+++ b/src/Tests/Domain/DurationTests.cs
@@ -5,23 +5,15 @@
 
     public class DurationTests
     {
-        public void Should_split_seconds_into_minutes_and_seconds()
+        [Input(60, 1, 0)]
+        [Input(61, 1, 1)]
+        [Input(45, 0, 45)]
+        [Input(0, 0, 0)]
+        public void Should_split_seconds_into_minutes_and_seconds(int totalSeconds, int expectedMinutes, int expectedSeconds)
         {
-            var duration = new Duration(60);
-            duration.Minutes.ShouldEqual(1);
-            duration.Seconds.ShouldEqual(0);
-
-            var minutesAndSeconds = new Duration(61);
-            minutesAndSeconds.Minutes.ShouldEqual(1);
-            minutesAndSeconds.Seconds.ShouldEqual(1);
-
-            var lessThanAMinute = new Duration(45);
-            lessThanAMinute.Minutes.ShouldEqual(0);
-            lessThanAMinute.Seconds.ShouldEqual(45);
-
-            var zero = new Duration(0);
-            zero.Minutes.ShouldEqual(0);
-            zero.Seconds.ShouldEqual(0);
+            var duration = new Duration(totalSeconds);
+            duration.Minutes.ShouldEqual(expectedMinutes);
+            duration.Seconds.ShouldEqual(expectedSeconds);
         }
     }
 }

--- a/src/Tests/Domain/DurationTests.cs
+++ b/src/Tests/Domain/DurationTests.cs
@@ -5,17 +5,6 @@
 
     public class DurationTests
     {
-        [Input(60, 1, 0)]
-        [Input(61, 1, 1)]
-        [Input(45, 0, 45)]
-        [Input(0, 0, 0)]
-        public void Should_split_seconds_into_minutes_and_seconds(int totalSeconds, int expectedMinutes, int expectedSeconds)
-        {
-            var duration = new Duration(totalSeconds);
-            duration.Minutes.ShouldEqual(expectedMinutes);
-            duration.Seconds.ShouldEqual(expectedSeconds);
-        }
-
         [Input(60, "1:00")]
         [Input(61, "1:01")]
         [Input(45, "0:45")]

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -47,10 +47,17 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Domain\DurationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj">
+      <Project>{F067D483-9E75-41E1-90EA-6B094F61CB61}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CustomConvention.cs" />
     <Compile Include="Domain\DurationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CustomConvention.cs" />
+    <Compile Include="Domain\AudioBookTests.cs" />
     <Compile Include="Domain\DurationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Shows example [Fixie](http://fixie.github.io/) tests, first using the [Default Convention](http://fixie.github.io/docs/default-convention/), then overriding with a [Custom Convention](http://fixie.github.io/docs/custom-conventions/) once I needed extra features.

Simply by including a reference to Fixie, I was able to take advantage of its default convention: Any public class ending with the word "Tests" is a test fixture, and any public void method on a test fixture is a test.

Because my example tests were calculator-like, I knew the tests would be more readable, more descriptive, and briefer if I used [parameterized tests](http://fixie.github.io/docs/parameterized-test-methods/), in which I provide an array of "these inputs should create those outputs" scenarios for a single template test method. (That, and what would I name all those methods? "Adding zero and zero should be zero. Adding 1 and 60 should be...") So I created a custom convention, keeping the same rules for test discovery and adding a `ParameterSource` to the convention's `Parameters` property. A `ParameterSource` tells Fixie, when a test method takes parameters, how it should populate those parameters with values. In this case, I'm using a custom attribute, `InputAttribute`. A test method can be decorated with one or more `[Input()]` attributes, each one providing an array of objects that should match up to each argument in the method's signature.

And I refactored as I went along, polishing both production code and the tests.
