### PR TITLE
Closes #4, adding AutoFixture for filling test arguments

### DIFF
--- a/src/Core/Domain/AudioBook.cs
+++ b/src/Core/Domain/AudioBook.cs
@@ -16,6 +16,11 @@
         {
             return Chapters.Sum(x => x.Duration);
         }
+
+        public void AddChapter(int durationTotalSeconds)
+        {
+            Chapters.Add(new AudioChapter(new Duration(durationTotalSeconds)));
+        }
     }
 
     public class AudioChapter

--- a/src/Tests/CustomConvention.cs
+++ b/src/Tests/CustomConvention.cs
@@ -27,15 +27,27 @@
         public IEnumerable<object[]> GetParameters(MethodInfo method)
         {
             if (method.HasOrInherits<InputAttribute>())
-            {
-                return method.GetCustomAttributes<InputAttribute>(true).Select(input => input.Parameters);
-            }
+                return ParameterSetsFilledFromInputAttributes(method);
 
+            if (method.GetParameters().Any())
+                return ParameterSetFilledByAutoFixture(method);
+
+            return NoParameterSets();
+        }
+
+        private static IEnumerable<object[]> ParameterSetsFilledFromInputAttributes(MethodInfo method)
+        {
+            return method.GetCustomAttributes<InputAttribute>(true).Select(input => input.Parameters);
+        }
+
+        private IEnumerable<object[]> ParameterSetFilledByAutoFixture(MethodInfo method)
+        {
             var fixture = new Ploeh.AutoFixture.Fixture();
-            var filledParameters = method.GetParameters().Select(p => Resolve(p, fixture)).ToArray();
-            if (filledParameters.Any())
-                return new[] { filledParameters };
-            
+            return new[] {method.GetParameters().Select(p => Resolve(p, fixture)).ToArray()};
+        }
+
+        private static IEnumerable<object[]> NoParameterSets()
+        {
             return Enumerable.Empty<object[]>();
         }
 

--- a/src/Tests/CustomConvention.cs
+++ b/src/Tests/CustomConvention.cs
@@ -30,8 +30,13 @@
             {
                 return method.GetCustomAttributes<InputAttribute>(true).Select(input => input.Parameters);
             }
+
             var fixture = new Ploeh.AutoFixture.Fixture();
-            return new[] { method.GetParameters().Select(p => Resolve(p, fixture)).ToArray() };
+            var filledParameters = method.GetParameters().Select(p => Resolve(p, fixture)).ToArray();
+            if (filledParameters.Any())
+                return new[] { filledParameters };
+            
+            return Enumerable.Empty<object[]>();
         }
 
         private object Resolve(ParameterInfo p, Ploeh.AutoFixture.Fixture fixture)

--- a/src/Tests/Domain/AudioBookTests.cs
+++ b/src/Tests/Domain/AudioBookTests.cs
@@ -6,6 +6,13 @@
 
     public class AudioBookTests
     {
+        private Fixture _fixture;
+
+        public AudioBookTests()
+        {
+            _fixture = new Fixture();
+        }
+
         public void Should_sum_chapter_durations_to_find_book_duration()
         {
             var book = new AudioBook();
@@ -18,10 +25,8 @@
 
         public void Should_put_many_chapters_in_a_book()
         {
-            var fixture = new Fixture();
-
             var book = new AudioBook();
-            fixture.AddManyTo(book.Chapters);
+            _fixture.AddManyTo(book.Chapters);
             book.GetDuration().TotalSeconds.ShouldBeGreaterThan(0);
         }
     }

--- a/src/Tests/Domain/AudioBookTests.cs
+++ b/src/Tests/Domain/AudioBookTests.cs
@@ -1,18 +1,11 @@
 ﻿namespace Tests.Domain
 {
     using Core.Domain;
-    using Should;
     using Ploeh.AutoFixture;
+    using Should;
 
     public class AudioBookTests
     {
-        private Fixture _fixture;
-
-        public AudioBookTests()
-        {
-            _fixture = new Fixture();
-        }
-
         public void Should_sum_chapter_durations_to_find_book_duration()
         {
             var book = new AudioBook();
@@ -23,10 +16,10 @@
             book.GetDuration().Display.ShouldEqual("2:58");
         }
 
-        public void Should_put_many_chapters_in_a_book()
+        public void Should_put_many_chapters_in_a_book(AudioBook book)
         {
-            var book = new AudioBook();
-            _fixture.AddManyTo(book.Chapters);
+            var fixture = new Fixture();
+            fixture.AddManyTo(book.Chapters);
             book.GetDuration().TotalSeconds.ShouldBeGreaterThan(0);
         }
     }

--- a/src/Tests/Domain/AudioBookTests.cs
+++ b/src/Tests/Domain/AudioBookTests.cs
@@ -16,10 +16,10 @@
         public void Should_sum_chapter_durations_to_find_book_duration()
         {
             var book = new AudioBook();
-            book.Chapters.Add(new AudioChapter(new Duration(60)));
-            book.Chapters.Add(new AudioChapter(new Duration(55)));
-            book.Chapters.Add(new AudioChapter(new Duration(0)));
-            book.Chapters.Add(new AudioChapter(new Duration(63)));
+            book.AddChapter(60);
+            book.AddChapter(55);
+            book.AddChapter(0);
+            book.AddChapter(63);
             book.GetDuration().Display.ShouldEqual("2:58");
         }
 

--- a/src/Tests/Domain/AudioBookTests.cs
+++ b/src/Tests/Domain/AudioBookTests.cs
@@ -2,6 +2,7 @@
 {
     using Core.Domain;
     using Should;
+    using Ploeh.AutoFixture;
 
     public class AudioBookTests
     {
@@ -13,6 +14,15 @@
             book.Chapters.Add(new AudioChapter(new Duration(0)));
             book.Chapters.Add(new AudioChapter(new Duration(63)));
             book.GetDuration().Display.ShouldEqual("2:58");
+        }
+
+        public void Should_put_many_chapters_in_a_book()
+        {
+            var fixture = new Fixture();
+
+            var book = new AudioBook();
+            fixture.AddManyTo(book.Chapters);
+            book.GetDuration().TotalSeconds.ShouldBeGreaterThan(0);
         }
     }
 }

--- a/src/Tests/Infrastructure/AutoFilledParameterSourceTests.cs
+++ b/src/Tests/Infrastructure/AutoFilledParameterSourceTests.cs
@@ -1,20 +1,67 @@
 ﻿namespace Tests.Infrastructure
 {
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Reflection;
+    using Core.Domain;
     using Should;
 
     public class AutoFilledParameterSourceTests
     {
-        public void Should_return_empty_collection_when_test_takes_no_args()
+        private readonly AutoFilled _source;
+
+        public AutoFilledParameterSourceTests()
         {
-            var source = new AutoFilled();
-            var results =
-                source.GetParameters(GetType()
-                    .GetMethod("HasNoParameters", BindingFlags.Instance | BindingFlags.NonPublic));
-            results.ShouldBeEmpty();
+            _source = new AutoFilled();
         }
 
-        private void HasNoParameters()
-        { }
+        public void Should_return_empty_collection_when_test_takes_no_args()
+        {
+            ParameterSetsFrom("HasNoParameters").ShouldBeEmpty();
+        }
+
+        public void Should_build_one_set_of_filled_parameters_when_using_AutoFixture()
+        {
+            var sets = ParameterSetsFrom("HasThreeParametersAndNoAttributes").ToArray();
+            sets.Count().ShouldEqual(1);
+            var parametersInTheSet = sets.Single();
+            parametersInTheSet.Count().ShouldEqual(3);
+        }
+
+        public void Should_build_one_set_of_filled_parameters_from_InputAttribute()
+        {
+            var sets = ParameterSetsFrom("HasTwoParametersAndOneInputAttribute").ToArray();
+            sets.Count().ShouldEqual(1);
+            var parametersInTheSet = sets.Single();
+            parametersInTheSet.Count().ShouldEqual(2);
+        }
+
+        public void Should_build_a_set_of_filled_parameters_for_each_InputAttribute()
+        {
+            var sets = ParameterSetsFrom("HasOneParameterAndThreeInputAttributes").ToArray();
+            sets.Count().ShouldEqual(3);
+            foreach (var parametersInTheSet in sets)
+            {
+                parametersInTheSet.Count().ShouldEqual(1);
+            }
+        }
+
+        private void HasNoParameters() { }
+
+        private void HasThreeParametersAndNoAttributes(string first, int second, AudioBook third) { }
+
+        [Input(24, "another")]
+        private void HasTwoParametersAndOneInputAttribute(int first, string second) { }
+
+        [Input("Smidge")]
+        [Input("Aurora")]
+        [Input("Agatha")]
+        private void HasOneParameterAndThreeInputAttributes(string kitty) { }
+
+        private IEnumerable<object[]> ParameterSetsFrom(string name)
+        {
+            var method = GetType().GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic);
+            return _source.GetParameters(method);
+        }
     }
 }

--- a/src/Tests/Infrastructure/AutoFilledParameterSourceTests.cs
+++ b/src/Tests/Infrastructure/AutoFilledParameterSourceTests.cs
@@ -1,0 +1,20 @@
+﻿namespace Tests.Infrastructure
+{
+    using System.Reflection;
+    using Should;
+
+    public class AutoFilledParameterSourceTests
+    {
+        public void Should_return_empty_collection_when_test_takes_no_args()
+        {
+            var source = new AutoFilled();
+            var results =
+                source.GetParameters(GetType()
+                    .GetMethod("HasNoParameters", BindingFlags.Instance | BindingFlags.NonPublic));
+            results.ShouldBeEmpty();
+        }
+
+        private void HasNoParameters()
+        { }
+    }
+}

--- a/src/Tests/Infrastructure/AutoFilledParameterSourceTests.cs
+++ b/src/Tests/Infrastructure/AutoFilledParameterSourceTests.cs
@@ -46,6 +46,31 @@
             }
         }
 
+        public void Should_use_AutoFixture_after_running_out_of_InputAttribute_parameters()
+        {
+            var parametersInTheSet = ParameterSetsFrom("HasMoreParametersThanTheInputAttribute").Single();
+            parametersInTheSet.Count().ShouldEqual(3);
+            parametersInTheSet.ElementAt(0).ShouldEqual("something");
+            parametersInTheSet.ElementAt(1).ShouldBeGreaterThan(0);
+            parametersInTheSet.ElementAt(2).ShouldNotBeNull();
+        }
+
+        public void Should_handle_InputAttributes_with_differing_numbers_of_parameters()
+        {
+            var sets = ParameterSetsFrom("HasTheInputAttributesWithDifferentNumbersOfParameters").ToArray();
+            sets.Count().ShouldEqual(2);
+
+            var oneInputParameter = sets.Single(s => s.ElementAt(0).Equals("has one"));
+            oneInputParameter.Count().ShouldEqual(3);
+            oneInputParameter.ElementAt(1).ShouldBeGreaterThan(0);
+            oneInputParameter.ElementAt(2).ShouldNotBeNull();
+
+            var twoInputParameters = sets.Single(s => s.ElementAt(0).Equals("has two"));
+            twoInputParameters.Count().ShouldEqual(3);
+            twoInputParameters.ElementAt(1).ShouldEqual(30345);
+            twoInputParameters.ElementAt(2).ShouldNotBeNull();
+        }
+
         private void HasNoParameters() { }
 
         private void HasThreeParametersAndNoAttributes(string first, int second, AudioBook third) { }
@@ -57,6 +82,13 @@
         [Input("Aurora")]
         [Input("Agatha")]
         private void HasOneParameterAndThreeInputAttributes(string kitty) { }
+
+        [Input("something")]
+        private void HasMoreParametersThanTheInputAttribute(string first, int second, AudioBook third) { }
+
+        [Input("has one")]
+        [Input("has two", 30345)]
+        private void HasTheInputAttributesWithDifferentNumbersOfParameters(string first, int second, AudioBook third) { }
 
         private IEnumerable<object[]> ParameterSetsFrom(string name)
         {

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -35,6 +35,9 @@
     <Reference Include="Fixie">
       <HintPath>..\packages\Fixie.1.0.0.1\lib\net45\Fixie.dll</HintPath>
     </Reference>
+    <Reference Include="Ploeh.AutoFixture">
+      <HintPath>..\packages\AutoFixture.3.23.0\lib\net40\Ploeh.AutoFixture.dll</HintPath>
+    </Reference>
     <Reference Include="Should">
       <HintPath>..\packages\Should.1.1.20\lib\Should.dll</HintPath>
     </Reference>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="CustomConvention.cs" />
     <Compile Include="Domain\AudioBookTests.cs" />
     <Compile Include="Domain\DurationTests.cs" />
+    <Compile Include="Infrastructure\AutoFilledParameterSourceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -64,6 +65,7 @@
       <Name>Core</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Tests/packages.config
+++ b/src/Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AutoFixture" version="3.23.0" targetFramework="net45" />
   <package id="Fixie" version="1.0.0.1" targetFramework="net45" />
   <package id="Should" version="1.1.20" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
[AutoFixture](https://github.com/AutoFixture/AutoFixture) populates an object with dummy data, allowing you to remove a lot of noise from the set up of your tests. (The [cheat sheet](https://github.com/AutoFixture/AutoFixture/wiki/Cheat-Sheet) gives an at-a-glance of what it can do.)

Pull request #10 on this project added support for parameterized tests to the [Fixie](http://fixie.github.io/) convention. This lets you exercise the same bit of code with different scenarios without writing repetitive test methods. The test method takes arguments for the inputs and expected outputs, and one or more `[Input()]` attributes on the test method provide values for those arguments. Each `[Input()]` attribute turns into a test case (as if you'd written a method for each one).

This change lets AutoFixture provide values for the test method's arguments, when the actual values aren't important. You can replace a lot of object construction and property assignments, when they aren't semantically significant to the test, by taking the objects as arguments to the method and letting AutoFixture fill them in.

Also with this pull request, you can combine the two means of filling a test method's arguments. Every parameter you provide in an `[Input()]` attribute will be used; any leftover ones will be handled by AutoFixture.

In this way, the Fixie convention provides the same behavior as AutoFixture's `AutoData` and `InlineAutoData` attributes without taking on a dependency to [xUnit](http://xunit.github.io/). This helps avoid some confusion for the dev team. On another project that used Fixie, we also referenced xUnit so we could use `AutoData`. At the time the [ReSharper test runner](https://www.jetbrains.com/resharper/features/unit_testing.html) could not run Fixie tests (but does run xUnit). Because of the reference to xUnit, you could kick off the ReSharper runner and it would look like it was running your tests&mdash;and it was, through xUnit. The continuous integration server, on the other hand, would run them through Fixie, which includes any test-wrapping behaviors we'd coded into the Fixie convention. "Works on my machine," but not on the CI server. Without the xUnit dependency, at least it is clear that ReSharper is not running your tests. (It doesn't even recognize them as tests.)

However, this does nothing to alleviate the team's confusion between "[AutoFixture](https://github.com/AutoFixture/AutoFixture) made by [ploeh](https://github.com/ploeh)," "[Fixie](https://github.com/fixie/fixie) made by [plioi](https://github.com/plioi)," and "[AutoMapper](https://github.com/AutoMapper/AutoMapper) made by [another Headspringer](https://github.com/jbogard)." You're on your own, there.
