### PR TITLE
Closes #11, adding support for tests run only on demand

### DIFF
--- a/src/Tests/AutoFilled.cs
+++ b/src/Tests/AutoFilled.cs
@@ -1,0 +1,71 @@
+namespace Tests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Fixie;
+    using Ploeh.AutoFixture.Kernel;
+
+    public class AutoFilled : ParameterSource
+    {
+        public IEnumerable<object[]> GetParameters(MethodInfo method)
+        {
+            if (method.HasOrInherits<InputAttribute>())
+                return ParameterSetsFilledFromInputAttributes(method);
+
+            if (method.GetParameters().Any())
+                return ParameterSetFilledByAutoFixture(method);
+
+            return NoParameterSets();
+        }
+
+        private IEnumerable<object[]> ParameterSetsFilledFromInputAttributes(MethodInfo method)
+        {
+            var sets = new List<object[]>();
+            var parametersToFill = method.GetParameters();
+            var numberOfParametersToFill = parametersToFill.Count();
+
+            var inputAttributes = method.GetCustomAttributes<InputAttribute>(true);
+            foreach (var inputAttribute in inputAttributes)
+            {
+                var filledParameters = new List<object>();
+
+                var providedParameters = inputAttribute.Parameters;
+                var numberOfProvidedParameters = providedParameters.Count();
+
+                filledParameters.AddRange(providedParameters);
+
+                if (numberOfProvidedParameters < numberOfParametersToFill)
+                {
+                    filledParameters.AddRange(ParametersFilledByAutoFixture(parametersToFill.Skip(numberOfProvidedParameters)));
+                }
+
+                sets.Add(filledParameters.ToArray());
+            }
+
+            return sets;
+        }
+
+        private IEnumerable<object[]> ParameterSetFilledByAutoFixture(MethodInfo method)
+        {
+            return new[] { ParametersFilledByAutoFixture(method.GetParameters()) };
+        }
+
+        private object[] ParametersFilledByAutoFixture(IEnumerable<ParameterInfo> parameters)
+        {
+            var fixture = new Ploeh.AutoFixture.Fixture();
+            return parameters.Select(p => Resolve(p, fixture)).ToArray();
+        }
+
+        private static IEnumerable<object[]> NoParameterSets()
+        {
+            return Enumerable.Empty<object[]>();
+        }
+
+        private object Resolve(ParameterInfo p, Ploeh.AutoFixture.Fixture fixture)
+        {
+            var context = new SpecimenContext(fixture);
+            return context.Resolve(p);
+        }
+    }
+}

--- a/src/Tests/CustomConvention.cs
+++ b/src/Tests/CustomConvention.cs
@@ -15,6 +15,15 @@
 
             Parameters
                 .Add<AutoFilled>();
+
+            CaseExecution
+                .Skip(DeveloperToolsWhenRunningTheWholeSuite);
+        }
+
+        private bool DeveloperToolsWhenRunningTheWholeSuite(Case testCase)
+        {
+            var isDeveloperTool = testCase.Method.Has<DeveloperToolAttribute>();
+            return isDeveloperTool && TargetMember != testCase.Method;
         }
     }
 
@@ -27,5 +36,10 @@
         }
 
         public object[] Parameters { get; private set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public class DeveloperToolAttribute : Attribute
+    {
     }
 }

--- a/src/Tests/CustomConvention.cs
+++ b/src/Tests/CustomConvention.cs
@@ -1,11 +1,7 @@
 ﻿namespace Tests
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
     using Fixie;
-    using Ploeh.AutoFixture.Kernel;
 
     public class CustomConvention : Convention
     {
@@ -19,69 +15,6 @@
 
             Parameters
                 .Add<AutoFilled>();
-        }
-    }
-
-    public class AutoFilled : ParameterSource
-    {
-        public IEnumerable<object[]> GetParameters(MethodInfo method)
-        {
-            if (method.HasOrInherits<InputAttribute>())
-                return ParameterSetsFilledFromInputAttributes(method);
-
-            if (method.GetParameters().Any())
-                return ParameterSetFilledByAutoFixture(method);
-
-            return NoParameterSets();
-        }
-
-        private IEnumerable<object[]> ParameterSetsFilledFromInputAttributes(MethodInfo method)
-        {
-            var sets = new List<object[]>();
-            var parametersToFill = method.GetParameters();
-            var numberOfParametersToFill = parametersToFill.Count();
-
-            var inputAttributes = method.GetCustomAttributes<InputAttribute>(true);
-            foreach (var inputAttribute in inputAttributes)
-            {
-                var filledParameters = new List<object>();
-
-                var providedParameters = inputAttribute.Parameters;
-                var numberOfProvidedParameters = providedParameters.Count();
-
-                filledParameters.AddRange(providedParameters);
-
-                if (numberOfProvidedParameters < numberOfParametersToFill)
-                {
-                    filledParameters.AddRange(ParametersFilledByAutoFixture(parametersToFill.Skip(numberOfProvidedParameters)));
-                }
-
-                sets.Add(filledParameters.ToArray());
-            }
-
-            return sets;
-        }
-
-        private IEnumerable<object[]> ParameterSetFilledByAutoFixture(MethodInfo method)
-        {
-            return new[] { ParametersFilledByAutoFixture(method.GetParameters()) };
-        }
-
-        private object[] ParametersFilledByAutoFixture(IEnumerable<ParameterInfo> parameters)
-        {
-            var fixture = new Ploeh.AutoFixture.Fixture();
-            return parameters.Select(p => Resolve(p, fixture)).ToArray();
-        }
-
-        private static IEnumerable<object[]> NoParameterSets()
-        {
-            return Enumerable.Empty<object[]>();
-        }
-
-        private object Resolve(ParameterInfo p, Ploeh.AutoFixture.Fixture fixture)
-        {
-            var context = new SpecimenContext(fixture);
-            return context.Resolve(p);
         }
     }
 

--- a/src/Tests/Infrastructure/IsbnGeneratorTests.cs
+++ b/src/Tests/Infrastructure/IsbnGeneratorTests.cs
@@ -1,0 +1,21 @@
+﻿namespace Tests.Infrastructure
+{
+    using System;
+
+    public class IsbnGeneratorTests
+    {
+        [DeveloperTool]
+        public void GenerateTenValidISBNs()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                Console.WriteLine(GenerateISBN());
+            }
+        }
+
+        private string GenerateISBN()
+        {
+            return "978-0-306-40615-7";
+        }
+    }
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -55,6 +55,9 @@
     <Compile Include="Domain\AudioBookTests.cs" />
     <Compile Include="Domain\DurationTests.cs" />
     <Compile Include="Infrastructure\AutoFilledParameterSourceTests.cs" />
+    <Compile Include="Infrastructure\IsbnGeneratorTests.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -50,6 +50,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AutoFilled.cs" />
     <Compile Include="CustomConvention.cs" />
     <Compile Include="Domain\AudioBookTests.cs" />
     <Compile Include="Domain\DurationTests.cs" />


### PR DESCRIPTION
Fixie will skip tests that are decorated with the `DeveloperTool` attribute, unless they are the only test being run. This is useful for utilities such as "generate me some random VINs/ISBNs/credit card numbers that will pass our regex validation." I've also used on-demand tests to send example output to a third party to validate our integration with their test system (of course we didn't want to hit their test servers on every commit, only when generating a new set of reports for them).

This implementation sets up a `Skip()` condition that checks, if the current test method has the `DeveloperTool` attribute, skip it if it was not the `TargetMember` that kicked off the run. The way `TargetMember` works, if you tell the test runner to run a single method, that method is the `TargetMember`; if you select a test class to run, the class is the `TargetMember`. When you run the whole suite, `TargetMember` will be null.

An alternative way to achieve these on-demand tests would be to add another `Where()` to the Fixie convention's `Methods` collection, so that a method counts as a test only if it doesn't have the attribute or is the only test being run. Otherwise, rather than being a skipped test, it isn't a test at all. This works with the [TestDriven.net runner](http://www.testdriven.net/), but will leave you unable to ever run the test under the Visual Studio runner. If the convention excludes the method from what it considers to be tests, Visual Studio won't list it as a test, so you have no spot to select and "Run Selected Tests." Therefore, the implementation in this pull request is to consider them as tests, but skip them, so that they show in the Visual Studio runner's Test Explorer window, giving you something to select and run on demand.

Note that the Visual Studio test runner displays skipped tests the same as if they had passed, even including them in the count of passed tests. If your continuous integration server recognizes skipped tests as separate from passed tests, this code will report them to the CI server correctly. You can prove to yourself that Visual Studio is not _actually running_ the skipped tests by making the test throw an exception; you'll see the exception when running the single test but not when running the suite. 
