### PR TITLE
Closes #23, setting default namespace for projects to include Headspring Labs

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{F067D483-9E75-41E1-90EA-6B094F61CB61}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Core</RootNamespace>
-    <AssemblyName>Core</AssemblyName>
+    <RootNamespace>Headspring.Labs.Core</RootNamespace>
+    <AssemblyName>Headspring.Labs.Core</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>

--- a/src/Core/Domain/AudioBook.cs
+++ b/src/Core/Domain/AudioBook.cs
@@ -1,4 +1,4 @@
-﻿namespace Core.Domain
+﻿namespace Headspring.Labs.Core.Domain
 {
     using System.Collections.Generic;
     using System.Linq;

--- a/src/Core/Domain/Duration.cs
+++ b/src/Core/Domain/Duration.cs
@@ -1,4 +1,4 @@
-﻿namespace Core.Domain
+﻿namespace Headspring.Labs.Core.Domain
 {
     public class Duration
     {

--- a/src/Tests/AutoFilled.cs
+++ b/src/Tests/AutoFilled.cs
@@ -1,4 +1,4 @@
-namespace Tests
+namespace Headspring.Labs.Tests
 {
     using System.Collections.Generic;
     using System.Linq;

--- a/src/Tests/CustomConvention.cs
+++ b/src/Tests/CustomConvention.cs
@@ -1,4 +1,4 @@
-﻿namespace Tests
+﻿namespace Headspring.Labs.Tests
 {
     using System;
     using Fixie;

--- a/src/Tests/Domain/AudioBookTests.cs
+++ b/src/Tests/Domain/AudioBookTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Tests.Domain
+﻿namespace Headspring.Labs.Tests.Domain
 {
     using Core.Domain;
     using Ploeh.AutoFixture;

--- a/src/Tests/Domain/DurationTests.cs
+++ b/src/Tests/Domain/DurationTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Tests.Domain
+﻿namespace Headspring.Labs.Tests.Domain
 {
     using Core.Domain;
     using Should;

--- a/src/Tests/Infrastructure/AutoFilledParameterSourceTests.cs
+++ b/src/Tests/Infrastructure/AutoFilledParameterSourceTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Tests.Infrastructure
+﻿namespace Headspring.Labs.Tests.Infrastructure
 {
     using System.Collections.Generic;
     using System.Linq;

--- a/src/Tests/Infrastructure/IsbnGeneratorTests.cs
+++ b/src/Tests/Infrastructure/IsbnGeneratorTests.cs
@@ -1,6 +1,7 @@
-﻿namespace Tests.Infrastructure
+﻿namespace Headspring.Labs.Tests.Infrastructure
 {
     using System;
+    using Tests;
 
     public class IsbnGeneratorTests
     {

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{A7B2675A-A2A9-4282-9FBE-73DA5F8B9F84}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Tests</RootNamespace>
-    <AssemblyName>Tests</AssemblyName>
+    <RootNamespace>Headspring.Labs.Tests</RootNamespace>
+    <AssemblyName>Headspring.Labs.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>


### PR DESCRIPTION
The namespaces for the projects are now prefaced with Headspring.Labs, for vanity's sake. The csproj files themselves, though, keep the shorter names to avoid noise in Visual Studio's Solution Explorer.
