### PR TITLE
Closes #31, setting up CI build on AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Reference-Project
 Example project in ASP.NET MVC using OSS libraries
+
+[![Build status](https://ci.appveyor.com/api/projects/status/iqd08ox4pel7k2n7/branch/master?svg=true)](https://ci.appveyor.com/project/scichelli/reference-project/branch/master)


### PR DESCRIPTION
Following the excellent advice from [Scott Hanselman on setting up AppVeyor as a free Continuous Integration service](http://www.hanselman.com/blog/AppVeyorAGoodContinuousIntegrationSystemIsAJoyToBehold.aspx), the only change to this project is adding the build status badge to the readme.

It was as straightforward as promised. The only bump I ran into was that the first build failed because `NuGet.exe` had not been committed to my `.nuget` folder, due to overzealous global gitignore rules. I found the problematic gitignore rule using [git check-ignore -v src\.nuget\NuGet.exe](http://git-scm.com/docs/git-check-ignore) to find the file (`gitignore_global.txt`) and line number with the relevant ignore rule.
