### PR TITLE
Closes #3, adding StructureMap for dependency injection

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -40,7 +40,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Domain\AudioBook.cs" />
+    <Compile Include="Domain\Book.cs" />
     <Compile Include="Domain\Duration.cs" />
+    <Compile Include="Persistence\ISession.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Core/Domain/Book.cs
+++ b/src/Core/Domain/Book.cs
@@ -1,0 +1,10 @@
+﻿namespace Headspring.Labs.Core.Domain
+{
+    using System;
+
+    public class Book
+    {
+        public Guid Id { get; set; }
+        public string Title { get; set; } 
+    }
+}

--- a/src/Core/Persistence/ISession.cs
+++ b/src/Core/Persistence/ISession.cs
@@ -1,0 +1,28 @@
+﻿namespace Headspring.Labs.Core.Persistence
+{
+    using System;
+    using System.Collections.Generic;
+    using Domain;
+
+    public interface ISession
+    {
+        IEnumerable<Book> GetAll();
+    }
+
+    public class InMemorySession : ISession
+    {
+        private static readonly List<Book> Books = new List<Book>();
+
+        public InMemorySession()
+        {
+            Books.Add(new Book{ Title = "Girl Genius", Id = Guid.NewGuid() });
+            Books.Add(new Book{ Title = "American Gods", Id = Guid.NewGuid() });
+            Books.Add(new Book{ Title = "Make: Electronics", Id = Guid.NewGuid() });
+        }
+
+        public IEnumerable<Book> GetAll()
+        {
+            return Books;
+        }
+    }
+}

--- a/src/Core/Persistence/ISession.cs
+++ b/src/Core/Persistence/ISession.cs
@@ -7,6 +7,7 @@
     public interface ISession
     {
         IEnumerable<Book> GetAll();
+        void Add(Book book);
     }
 
     public class InMemorySession : ISession
@@ -23,6 +24,11 @@
         public IEnumerable<Book> GetAll()
         {
             return Books;
+        }
+
+        public void Add(Book book)
+        {
+            Books.Add(book);
         }
     }
 }

--- a/src/Tests/CustomConvention.cs
+++ b/src/Tests/CustomConvention.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using Fixie;
+    using UI.DependencyResolution;
 
     public class CustomConvention : Convention
     {
@@ -16,8 +17,18 @@
             Parameters
                 .Add<AutoFilled>();
 
+            ClassExecution
+                .CreateInstancePerClass()
+                .UsingFactory(GetFromContainer);
+
             CaseExecution
                 .Skip(DeveloperToolsWhenRunningTheWholeSuite);
+        }
+
+        private object GetFromContainer(Type testClass)
+        {
+            var container = IoC.Initialize();
+            return container.GetInstance(testClass);
         }
 
         private bool DeveloperToolsWhenRunningTheWholeSuite(Case testCase)

--- a/src/Tests/Features/Library/AddEditHandlerTests.cs
+++ b/src/Tests/Features/Library/AddEditHandlerTests.cs
@@ -1,0 +1,24 @@
+﻿namespace Headspring.Labs.Tests.Features.Library
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Core.Domain;
+    using Core.Persistence;
+    using Should;
+    using UI.Features.Library;
+
+    public class AddEditHandlerTests
+    {
+        public void Should_add_book_to_collection()
+        {
+            var session = new FakeSession();
+            var handler = new AddEditHandler(session);
+            var title = Guid.NewGuid().ToString();
+
+            handler.Handle(new AddEditViewModel {Title = title});
+
+            session.GetAll().Any(b => b.Title == title).ShouldBeTrue("Should map ViewModel to domain and send to session");
+        }
+    }
+}

--- a/src/Tests/Features/Library/AddEditHandlerTests.cs
+++ b/src/Tests/Features/Library/AddEditHandlerTests.cs
@@ -1,10 +1,7 @@
 ﻿namespace Headspring.Labs.Tests.Features.Library
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
-    using Core.Domain;
-    using Core.Persistence;
     using Should;
     using UI.Features.Library;
 

--- a/src/Tests/Features/Library/FakeSession.cs
+++ b/src/Tests/Features/Library/FakeSession.cs
@@ -1,0 +1,27 @@
+﻿namespace Headspring.Labs.Tests.Features.Library
+{
+    using System;
+    using System.Collections.Generic;
+    using Core.Domain;
+    using Core.Persistence;
+
+    public class FakeSession : ISession
+    {
+        private readonly List<Book> _books = new List<Book>();
+
+        public void AddBook(string title)
+        {
+            Add(new Book { Id = Guid.NewGuid(), Title = title });
+        }
+
+        public IEnumerable<Book> GetAll()
+        {
+            return _books;
+        }
+
+        public void Add(Book book)
+        {
+            _books.Add(book);
+        }
+    }
+}

--- a/src/Tests/Features/Library/IndexHandlerTests.cs
+++ b/src/Tests/Features/Library/IndexHandlerTests.cs
@@ -1,23 +1,45 @@
 ﻿namespace Headspring.Labs.Tests.Features.Library
 {
     using System.Linq;
+    using Core.Persistence;
     using Should;
     using UI.Features.Library;
 
     public class IndexHandlerTests
     {
+        private readonly ISession _session;
+
+        public IndexHandlerTests(ISession session)
+        {
+            _session = session;
+        }
+
         public void Should_map_books_to_view()
         {
-            var session = new FakeSession();
-            session.AddBook("Book 1");
-            session.AddBook("Book 2");
-            session.AddBook("Book 3");
-            var handler = new IndexHandler(session);
+            var fakeSession = new FakeSession();
+            fakeSession.AddBook("Book 1");
+            fakeSession.AddBook("Book 2");
+            fakeSession.AddBook("Book 3");
+            var handler = new IndexHandler(fakeSession);
 
             var result = handler.Handle(new IndexQuery());
 
             result.Books.Count.ShouldEqual(3);
             result.Books.Any(b => b.Title == "Book 2").ShouldBeTrue("Should find a book from the persistence session in the mapped ViewModel");
+        }
+
+        /// <summary>
+        /// This is not testing anything useful; instead it is demonstrating that, if you want your test to use the same 
+        /// StructureMap-provided instance that your production code will get, you can take the interface as an argument 
+        /// to the test fixture class's constructor.
+        /// </summary>
+        public void Should_do_something_to_demo_the_ISession_fetched_from_StructureMap()
+        {
+            var handler = new IndexHandler(_session);
+
+            var result = handler.Handle(new IndexQuery());
+
+            result.Books.Any(b => b.Title == "Girl Genius").ShouldBeTrue("Should find a book from our concrete implementation of ISession");
         }
     }
 }

--- a/src/Tests/Features/Library/IndexHandlerTests.cs
+++ b/src/Tests/Features/Library/IndexHandlerTests.cs
@@ -1,0 +1,42 @@
+﻿namespace Headspring.Labs.Tests.Features.Library
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Core.Domain;
+    using Core.Persistence;
+    using Should;
+    using UI.Features.Library;
+
+    public class IndexHandlerTests
+    {
+        public void Should_map_books_to_view()
+        {
+            var session = new FakeSession();
+            session.AddBook("Book 1");
+            session.AddBook("Book 2");
+            session.AddBook("Book 3");
+            var handler = new IndexHandler(session);
+
+            var result = handler.Handle(new IndexQuery());
+
+            result.Books.Count.ShouldEqual(3);
+            result.Books.Any(b => b.Title == "Book 2").ShouldBeTrue("Should find a book from the persistence session in the mapped ViewModel");
+        }
+
+        public class FakeSession : ISession
+        {
+            private static readonly List<Book> Books = new List<Book>();
+
+            public void AddBook(string title)
+            {
+                Books.Add(new Book{Id = Guid.NewGuid(), Title = title});
+            }
+
+            public IEnumerable<Book> GetAll()
+            {
+                return Books;
+            }
+        }
+    }
+}

--- a/src/Tests/Features/Library/IndexHandlerTests.cs
+++ b/src/Tests/Features/Library/IndexHandlerTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Headspring.Labs.Tests.Features.Library
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
-    using Core.Domain;
-    using Core.Persistence;
     using Should;
     using UI.Features.Library;
 
@@ -22,21 +18,6 @@
 
             result.Books.Count.ShouldEqual(3);
             result.Books.Any(b => b.Title == "Book 2").ShouldBeTrue("Should find a book from the persistence session in the mapped ViewModel");
-        }
-
-        public class FakeSession : ISession
-        {
-            private static readonly List<Book> Books = new List<Book>();
-
-            public void AddBook(string title)
-            {
-                Books.Add(new Book{Id = Guid.NewGuid(), Title = title});
-            }
-
-            public IEnumerable<Book> GetAll()
-            {
-                return Books;
-            }
         }
     }
 }

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -54,6 +54,8 @@
     <Compile Include="CustomConvention.cs" />
     <Compile Include="Domain\AudioBookTests.cs" />
     <Compile Include="Domain\DurationTests.cs" />
+    <Compile Include="Features\Library\AddEditHandlerTests.cs" />
+    <Compile Include="Features\Library\FakeSession.cs" />
     <Compile Include="Features\Library\IndexHandlerTests.cs" />
     <Compile Include="Infrastructure\AutoFilledParameterSourceTests.cs" />
     <Compile Include="Infrastructure\IsbnGeneratorTests.cs">

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="CustomConvention.cs" />
     <Compile Include="Domain\AudioBookTests.cs" />
     <Compile Include="Domain\DurationTests.cs" />
+    <Compile Include="Features\Library\IndexHandlerTests.cs" />
     <Compile Include="Infrastructure\AutoFilledParameterSourceTests.cs" />
     <Compile Include="Infrastructure\IsbnGeneratorTests.cs">
       <SubType>Code</SubType>
@@ -67,6 +68,10 @@
     <ProjectReference Include="..\Core\Core.csproj">
       <Project>{F067D483-9E75-41E1-90EA-6B094F61CB61}</Project>
       <Name>Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\UI\UI.csproj">
+      <Project>{69BB74F3-DCE2-4A34-AC7E-E725FBE703A0}</Project>
+      <Name>UI</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup />

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -41,6 +41,14 @@
     <Reference Include="Should">
       <HintPath>..\packages\Should.1.1.20\lib\Should.dll</HintPath>
     </Reference>
+    <Reference Include="StructureMap, Version=3.1.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\structuremap.3.1.4.143\lib\net40\StructureMap.dll</HintPath>
+    </Reference>
+    <Reference Include="StructureMap.Net4, Version=3.1.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\structuremap.3.1.4.143\lib\net40\StructureMap.Net4.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Tests/packages.config
+++ b/src/Tests/packages.config
@@ -3,4 +3,5 @@
   <package id="AutoFixture" version="3.23.0" targetFramework="net45" />
   <package id="Fixie" version="1.0.0.1" targetFramework="net45" />
   <package id="Should" version="1.1.20" targetFramework="net45" />
+  <package id="structuremap" version="3.1.4.143" targetFramework="net45" />
 </packages>

--- a/src/UI/App_Start/StructuremapMvc.cs
+++ b/src/UI/App_Start/StructuremapMvc.cs
@@ -1,0 +1,56 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="StructuremapMvc.cs" company="Web Advanced">
+// Copyright 2012 Web Advanced (www.webadvanced.com)
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using Headspring.Labs.UI.App_Start;
+
+using WebActivatorEx;
+
+[assembly: PreApplicationStartMethod(typeof(StructuremapMvc), "Start")]
+[assembly: ApplicationShutdownMethod(typeof(StructuremapMvc), "End")]
+
+namespace Headspring.Labs.UI.App_Start {
+	using System.Web.Mvc;
+
+    using Microsoft.Web.Infrastructure.DynamicModuleHelper;
+
+	using Headspring.Labs.UI.DependencyResolution;
+
+    using StructureMap;
+    
+	public static class StructuremapMvc {
+        #region Public Properties
+
+        public static StructureMapDependencyScope StructureMapDependencyScope { get; set; }
+
+        #endregion
+		
+		#region Public Methods and Operators
+		
+		public static void End() {
+            StructureMapDependencyScope.Dispose();
+        }
+		
+        public static void Start() {
+            IContainer container = IoC.Initialize();
+            StructureMapDependencyScope = new StructureMapDependencyScope(container);
+            DependencyResolver.SetResolver(StructureMapDependencyScope);
+            DynamicModuleUtility.RegisterModule(typeof(StructureMapScopeModule));
+        }
+
+        #endregion
+    }
+}

--- a/src/UI/Controllers/LibraryController.cs
+++ b/src/UI/Controllers/LibraryController.cs
@@ -1,0 +1,23 @@
+﻿namespace Headspring.Labs.UI.Controllers
+{
+    using System.Collections.Generic;
+    using System.Web.Mvc;
+    using Features.Library;
+
+    public class LibraryController : Controller
+    {
+        public ViewResult Index()
+        {
+            var viewModel = new IndexViewModel
+            {
+                Books = new List<IndexViewModel.BookViewModel>
+                {
+                    new IndexViewModel.BookViewModel{Title = "Girl Genius"},
+                    new IndexViewModel.BookViewModel{Title = "American Gods"},
+                    new IndexViewModel.BookViewModel{Title = "Make: Electronics"},
+                }
+            };
+            return View(viewModel);
+        }
+    }
+}

--- a/src/UI/Controllers/LibraryController.cs
+++ b/src/UI/Controllers/LibraryController.cs
@@ -1,7 +1,6 @@
 ﻿namespace Headspring.Labs.UI.Controllers
 {
     using System.Web.Mvc;
-    using Core.Domain;
     using Core.Persistence;
     using Features.Library;
 
@@ -23,7 +22,7 @@
         [HttpPost]
         public ActionResult Add(AddEditViewModel model)
         {
-            _session.Add(new Book {Title = model.Title});
+            new AddEditHandler(_session).Handle(model);
             return RedirectToAction("Index");
         }
     }

--- a/src/UI/Controllers/LibraryController.cs
+++ b/src/UI/Controllers/LibraryController.cs
@@ -6,9 +6,11 @@
 
     public class LibraryController : Controller
     {
+        private static readonly ISession _session = new InMemorySession();
+
         public ViewResult Index()
         {
-            var viewModel = new IndexHandler(new InMemorySession()).Handle(new IndexQuery());
+            var viewModel = new IndexHandler(_session).Handle(new IndexQuery());
             return View(viewModel);
         }
 

--- a/src/UI/Controllers/LibraryController.cs
+++ b/src/UI/Controllers/LibraryController.cs
@@ -19,5 +19,16 @@
             };
             return View(viewModel);
         }
+
+        public ViewResult Add()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        public ActionResult Add(AddEditViewModel model)
+        {
+            return RedirectToAction("Index");
+        }
     }
 }

--- a/src/UI/Controllers/LibraryController.cs
+++ b/src/UI/Controllers/LibraryController.cs
@@ -1,13 +1,14 @@
 ﻿namespace Headspring.Labs.UI.Controllers
 {
     using System.Web.Mvc;
+    using Core.Persistence;
     using Features.Library;
 
     public class LibraryController : Controller
     {
         public ViewResult Index()
         {
-            var viewModel = new IndexHandler().Handle(new IndexQuery());
+            var viewModel = new IndexHandler(new InMemorySession()).Handle(new IndexQuery());
             return View(viewModel);
         }
 

--- a/src/UI/Controllers/LibraryController.cs
+++ b/src/UI/Controllers/LibraryController.cs
@@ -1,6 +1,7 @@
 ﻿namespace Headspring.Labs.UI.Controllers
 {
     using System.Web.Mvc;
+    using Core.Domain;
     using Core.Persistence;
     using Features.Library;
 
@@ -22,6 +23,7 @@
         [HttpPost]
         public ActionResult Add(AddEditViewModel model)
         {
+            _session.Add(new Book {Title = model.Title});
             return RedirectToAction("Index");
         }
     }

--- a/src/UI/Controllers/LibraryController.cs
+++ b/src/UI/Controllers/LibraryController.cs
@@ -1,6 +1,5 @@
 ﻿namespace Headspring.Labs.UI.Controllers
 {
-    using System.Collections.Generic;
     using System.Web.Mvc;
     using Features.Library;
 
@@ -8,15 +7,7 @@
     {
         public ViewResult Index()
         {
-            var viewModel = new IndexViewModel
-            {
-                Books = new List<IndexViewModel.BookViewModel>
-                {
-                    new IndexViewModel.BookViewModel{Title = "Girl Genius"},
-                    new IndexViewModel.BookViewModel{Title = "American Gods"},
-                    new IndexViewModel.BookViewModel{Title = "Make: Electronics"},
-                }
-            };
+            var viewModel = new IndexHandler().Handle(new IndexQuery());
             return View(viewModel);
         }
 

--- a/src/UI/Controllers/LibraryController.cs
+++ b/src/UI/Controllers/LibraryController.cs
@@ -6,7 +6,12 @@
 
     public class LibraryController : Controller
     {
-        private static readonly ISession _session = new InMemorySession();
+        private readonly ISession _session;
+
+        public LibraryController(ISession session)
+        {
+            _session = session;
+        }
 
         public ViewResult Index()
         {

--- a/src/UI/DependencyResolution/ControllerConvention.cs
+++ b/src/UI/DependencyResolution/ControllerConvention.cs
@@ -1,0 +1,38 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ControllerConvention.cs" company="Web Advanced">
+// Copyright 2012 Web Advanced (www.webadvanced.com)
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Headspring.Labs.UI.DependencyResolution {
+    using System;
+    using System.Web.Mvc;
+
+    using StructureMap.Configuration.DSL;
+    using StructureMap.Graph;
+    using StructureMap.Pipeline;
+    using StructureMap.TypeRules;
+
+    public class ControllerConvention : IRegistrationConvention {
+        #region Public Methods and Operators
+
+        public void Process(Type type, Registry registry) {
+            if (type.CanBeCastTo<Controller>() && !type.IsAbstract) {
+                registry.For(type).LifecycleIs(new UniquePerRequestLifecycle());
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/UI/DependencyResolution/DefaultRegistry.cs
+++ b/src/UI/DependencyResolution/DefaultRegistry.cs
@@ -1,0 +1,37 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DefaultRegistry.cs" company="Web Advanced">
+// Copyright 2012 Web Advanced (www.webadvanced.com)
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Headspring.Labs.UI.DependencyResolution {
+    using StructureMap.Configuration.DSL;
+    using StructureMap.Graph;
+	
+    public class DefaultRegistry : Registry {
+        #region Constructors and Destructors
+
+        public DefaultRegistry() {
+            Scan(
+                scan => {
+                    scan.TheCallingAssembly();
+                    scan.WithDefaultConventions();
+					scan.With(new ControllerConvention());
+                });
+            //For<IExample>().Use<Example>();
+        }
+
+        #endregion
+    }
+}

--- a/src/UI/DependencyResolution/DefaultRegistry.cs
+++ b/src/UI/DependencyResolution/DefaultRegistry.cs
@@ -16,6 +16,7 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 namespace Headspring.Labs.UI.DependencyResolution {
+    using Core.Persistence;
     using StructureMap.Configuration.DSL;
     using StructureMap.Graph;
 	
@@ -27,9 +28,9 @@ namespace Headspring.Labs.UI.DependencyResolution {
                 scan => {
                     scan.TheCallingAssembly();
                     scan.WithDefaultConventions();
-					scan.With(new ControllerConvention());
+                    scan.With(new ControllerConvention());
                 });
-            //For<IExample>().Use<Example>();
+            For<ISession>().Use<InMemorySession>().Singleton();
         }
 
         #endregion

--- a/src/UI/DependencyResolution/IoC.cs
+++ b/src/UI/DependencyResolution/IoC.cs
@@ -16,11 +16,14 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 
-namespace Headspring.Labs.UI.DependencyResolution {
+namespace Headspring.Labs.UI.DependencyResolution
+{
     using StructureMap;
-	
-    public static class IoC {
-        public static IContainer Initialize() {
+
+    public static class IoC
+    {
+        public static IContainer Initialize()
+        {
             return new Container(c => c.AddRegistry<DefaultRegistry>());
         }
     }

--- a/src/UI/DependencyResolution/IoC.cs
+++ b/src/UI/DependencyResolution/IoC.cs
@@ -1,0 +1,27 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IoC.cs" company="Web Advanced">
+// Copyright 2012 Web Advanced (www.webadvanced.com)
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+
+namespace Headspring.Labs.UI.DependencyResolution {
+    using StructureMap;
+	
+    public static class IoC {
+        public static IContainer Initialize() {
+            return new Container(c => c.AddRegistry<DefaultRegistry>());
+        }
+    }
+}

--- a/src/UI/DependencyResolution/StructureMapDependencyScope.cs
+++ b/src/UI/DependencyResolution/StructureMapDependencyScope.cs
@@ -1,0 +1,122 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="StructureMapDependencyScope.cs" company="Web Advanced">
+// Copyright 2012 Web Advanced (www.webadvanced.com)
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Headspring.Labs.UI.DependencyResolution {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Web;
+
+    using Microsoft.Practices.ServiceLocation;
+
+    using StructureMap;
+	
+    /// <summary>
+    /// The structure map dependency scope.
+    /// </summary>
+    public class StructureMapDependencyScope : ServiceLocatorImplBase {
+        #region Constants and Fields
+
+        private const string NestedContainerKey = "Nested.Container.Key";
+
+        #endregion
+
+        #region Constructors and Destructors
+
+        public StructureMapDependencyScope(IContainer container) {
+            if (container == null) {
+                throw new ArgumentNullException("container");
+            }
+            Container = container;
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public IContainer Container { get; set; }
+
+        public IContainer CurrentNestedContainer {
+            get {
+                return (IContainer)HttpContext.Items[NestedContainerKey];
+            }
+            set {
+                HttpContext.Items[NestedContainerKey] = value;
+            }
+        }
+
+        #endregion
+
+        #region Properties
+
+        private HttpContextBase HttpContext {
+            get {
+                var ctx = Container.TryGetInstance<HttpContextBase>();
+                return ctx ?? new HttpContextWrapper(System.Web.HttpContext.Current);
+            }
+        }
+
+        #endregion
+
+        #region Public Methods and Operators
+
+        public void CreateNestedContainer() {
+            if (CurrentNestedContainer != null) {
+                return;
+            }
+            CurrentNestedContainer = Container.GetNestedContainer();
+        }
+
+        public void Dispose() {
+            DisposeNestedContainer();
+            Container.Dispose();
+        }
+
+        public void DisposeNestedContainer() {
+            if (CurrentNestedContainer != null) {
+                CurrentNestedContainer.Dispose();
+				CurrentNestedContainer = null;
+            }
+        }
+
+        public IEnumerable<object> GetServices(Type serviceType) {
+            return DoGetAllInstances(serviceType);
+        }
+
+        #endregion
+
+        #region Methods
+
+        protected override IEnumerable<object> DoGetAllInstances(Type serviceType) {
+            return (CurrentNestedContainer ?? Container).GetAllInstances(serviceType).Cast<object>();
+        }
+
+        protected override object DoGetInstance(Type serviceType, string key) {
+            IContainer container = (CurrentNestedContainer ?? Container);
+
+            if (string.IsNullOrEmpty(key)) {
+                return serviceType.IsAbstract || serviceType.IsInterface
+                    ? container.TryGetInstance(serviceType)
+                    : container.GetInstance(serviceType);
+            }
+
+            return container.GetInstance(serviceType, key);
+        }
+
+        #endregion
+    }
+}

--- a/src/UI/DependencyResolution/StructureMapScopeModule.cs
+++ b/src/UI/DependencyResolution/StructureMapScopeModule.cs
@@ -1,0 +1,24 @@
+namespace Headspring.Labs.UI.DependencyResolution {
+    using System.Web;
+
+    using Headspring.Labs.UI.App_Start;
+
+    using StructureMap.Web.Pipeline;
+
+    public class StructureMapScopeModule : IHttpModule {
+        #region Public Methods and Operators
+
+        public void Dispose() {
+        }
+
+        public void Init(HttpApplication context) {
+            context.BeginRequest += (sender, e) => StructuremapMvc.StructureMapDependencyScope.CreateNestedContainer();
+            context.EndRequest += (sender, e) => {
+                HttpContextLifecycle.DisposeAndClearAll();
+                StructuremapMvc.StructureMapDependencyScope.DisposeNestedContainer();
+            };
+        }
+
+        #endregion
+    }
+}

--- a/src/UI/Features/Library/Add.cshtml
+++ b/src/UI/Features/Library/Add.cshtml
@@ -1,0 +1,9 @@
+﻿@model Headspring.Labs.UI.Features.Library.AddEditViewModel
+
+@{ ViewBag.Title = "Add Title";}
+
+@using (Html.BeginForm())
+{
+    <p>@Html.TextBoxFor(m => m.Title)</p>
+    <p><input type="submit" value="Submit"/> @Html.ActionLink("Cancel", "Index")</p>
+}

--- a/src/UI/Features/Library/AddEditHandler.cs
+++ b/src/UI/Features/Library/AddEditHandler.cs
@@ -1,0 +1,26 @@
+﻿namespace Headspring.Labs.UI.Features.Library
+{
+    using Core.Domain;
+    using Core.Persistence;
+    using Infrastructure;
+
+    public class AddEditHandler : IRequestHandler<AddEditViewModel, Book>
+    {
+        private readonly ISession _session;
+
+        public AddEditHandler(ISession session)
+        {
+            _session = session;
+        }
+
+        public Book Handle(AddEditViewModel message)
+        {
+            if (message.Id != null)
+                throw new System.NotImplementedException(); //Edit not yet implemented.
+
+            var book = new Book {Title = message.Title};
+            _session.Add(book);
+            return book;
+        }
+    }
+}

--- a/src/UI/Features/Library/AddEditViewModel.cs
+++ b/src/UI/Features/Library/AddEditViewModel.cs
@@ -1,0 +1,10 @@
+﻿namespace Headspring.Labs.UI.Features.Library
+{
+    using System;
+
+    public class AddEditViewModel
+    {
+        public Guid? Id { get; set; }
+        public string Title { get; set; }
+    }
+}

--- a/src/UI/Features/Library/AddEditViewModel.cs
+++ b/src/UI/Features/Library/AddEditViewModel.cs
@@ -1,8 +1,10 @@
 ﻿namespace Headspring.Labs.UI.Features.Library
 {
     using System;
+    using Core.Domain;
+    using Infrastructure;
 
-    public class AddEditViewModel
+    public class AddEditViewModel : IRequest<Book>
     {
         public Guid? Id { get; set; }
         public string Title { get; set; }

--- a/src/UI/Features/Library/Index.cshtml
+++ b/src/UI/Features/Library/Index.cshtml
@@ -1,0 +1,10 @@
+﻿@model Headspring.Labs.UI.Features.Library.IndexViewModel
+
+@{ ViewBag.Title = "Library";}
+
+<ul>
+    @foreach (var book in Model.Books)
+    {
+        <li>@book.Title</li>
+    }
+</ul>

--- a/src/UI/Features/Library/Index.cshtml
+++ b/src/UI/Features/Library/Index.cshtml
@@ -2,6 +2,8 @@
 
 @{ ViewBag.Title = "Library";}
 
+@Html.ActionLink("Add", "Add")
+
 <ul>
     @foreach (var book in Model.Books)
     {

--- a/src/UI/Features/Library/IndexHandler.cs
+++ b/src/UI/Features/Library/IndexHandler.cs
@@ -1,20 +1,24 @@
 ﻿namespace Headspring.Labs.UI.Features.Library
 {
-    using System.Collections.Generic;
+    using System.Linq;
+    using Core.Persistence;
     using Infrastructure;
 
     public class IndexHandler : IRequestHandler<IndexQuery, IndexViewModel> 
     {
+        private readonly ISession _session;
+
+        public IndexHandler(ISession session)
+        {
+            _session = session;
+        }
+
         public IndexViewModel Handle(IndexQuery message)
         {
+            var books = _session.GetAll();
             var model = new IndexViewModel
             {
-                Books = new List<IndexViewModel.BookViewModel>
-                {
-                    new IndexViewModel.BookViewModel{Title = "Girl Genius"},
-                    new IndexViewModel.BookViewModel{Title = "American Gods"},
-                    new IndexViewModel.BookViewModel{Title = "Make: Electronics"},
-                }
+                Books = books.Select(b => new IndexViewModel.BookViewModel{Id = b.Id, Title = b.Title}).ToList()
             };
             return model;
         }

--- a/src/UI/Features/Library/IndexHandler.cs
+++ b/src/UI/Features/Library/IndexHandler.cs
@@ -1,0 +1,17 @@
+﻿namespace Headspring.Labs.UI.Features.Library
+{
+    using System;
+    using Infrastructure;
+
+    public class IndexHandler : IRequestHandler<IndexQuery, IndexViewModel> 
+    {
+        public IndexViewModel Handle(IndexQuery message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class IndexQuery : IRequest<IndexViewModel>
+    {
+    }
+}

--- a/src/UI/Features/Library/IndexHandler.cs
+++ b/src/UI/Features/Library/IndexHandler.cs
@@ -1,13 +1,22 @@
 ﻿namespace Headspring.Labs.UI.Features.Library
 {
-    using System;
+    using System.Collections.Generic;
     using Infrastructure;
 
     public class IndexHandler : IRequestHandler<IndexQuery, IndexViewModel> 
     {
         public IndexViewModel Handle(IndexQuery message)
         {
-            throw new NotImplementedException();
+            var model = new IndexViewModel
+            {
+                Books = new List<IndexViewModel.BookViewModel>
+                {
+                    new IndexViewModel.BookViewModel{Title = "Girl Genius"},
+                    new IndexViewModel.BookViewModel{Title = "American Gods"},
+                    new IndexViewModel.BookViewModel{Title = "Make: Electronics"},
+                }
+            };
+            return model;
         }
     }
 

--- a/src/UI/Features/Library/IndexViewModel.cs
+++ b/src/UI/Features/Library/IndexViewModel.cs
@@ -1,0 +1,16 @@
+﻿namespace Headspring.Labs.UI.Features.Library
+{
+    using System.Collections.Generic;
+    using System;
+
+    public class IndexViewModel
+    {
+        public IList<BookViewModel> Books { get; set; }
+
+        public class BookViewModel
+        {
+            public Guid Id { get; set; }
+            public string Title { get; set; }
+        }
+    }
+}

--- a/src/UI/Infrastructure/IRequest.cs
+++ b/src/UI/Infrastructure/IRequest.cs
@@ -1,0 +1,10 @@
+﻿namespace Headspring.Labs.UI.Infrastructure
+{
+    public interface IRequest<out TResponse> { }
+
+    public interface IRequestHandler<in TRequest, out TResponse>
+        where TRequest : IRequest<TResponse>
+    {
+        TResponse Handle(TRequest message);
+    } 
+}

--- a/src/UI/UI.csproj
+++ b/src/UI/UI.csproj
@@ -140,10 +140,12 @@
     <Compile Include="DependencyResolution\StructureMapScopeModule.cs" />
     <Compile Include="Extensions\FeatureViewLocationRazorViewEngine.cs" />
     <Compile Include="Features\Library\AddEditViewModel.cs" />
+    <Compile Include="Features\Library\IndexHandler.cs" />
     <Compile Include="Features\Library\IndexViewModel.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
+    <Compile Include="Infrastructure\IRequest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="App_Start\ViewEngineConfig.cs" />
   </ItemGroup>

--- a/src/UI/UI.csproj
+++ b/src/UI/UI.csproj
@@ -112,6 +112,7 @@
     <Content Include="Features\Shared\_Layout.cshtml" />
     <Content Include="Features\Home\Index.cshtml" />
     <Content Include="Features\Web.config" />
+    <Content Include="Features\Library\Index.cshtml" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>
@@ -130,12 +131,14 @@
     <Compile Include="App_Start\RouteConfig.cs" />
     <Compile Include="App_Start\StructuremapMvc.cs" />
     <Compile Include="Controllers\HomeController.cs" />
+    <Compile Include="Controllers\LibraryController.cs" />
     <Compile Include="DependencyResolution\ControllerConvention.cs" />
     <Compile Include="DependencyResolution\DefaultRegistry.cs" />
     <Compile Include="DependencyResolution\IoC.cs" />
     <Compile Include="DependencyResolution\StructureMapDependencyScope.cs" />
     <Compile Include="DependencyResolution\StructureMapScopeModule.cs" />
     <Compile Include="Extensions\FeatureViewLocationRazorViewEngine.cs" />
+    <Compile Include="Features\Library\IndexViewModel.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>

--- a/src/UI/UI.csproj
+++ b/src/UI/UI.csproj
@@ -113,6 +113,7 @@
     <Content Include="Features\Home\Index.cshtml" />
     <Content Include="Features\Web.config" />
     <Content Include="Features\Library\Index.cshtml" />
+    <Content Include="Features\Library\Add.cshtml" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>
@@ -138,6 +139,7 @@
     <Compile Include="DependencyResolution\StructureMapDependencyScope.cs" />
     <Compile Include="DependencyResolution\StructureMapScopeModule.cs" />
     <Compile Include="Extensions\FeatureViewLocationRazorViewEngine.cs" />
+    <Compile Include="Features\Library\AddEditViewModel.cs" />
     <Compile Include="Features\Library\IndexViewModel.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>

--- a/src/UI/UI.csproj
+++ b/src/UI/UI.csproj
@@ -41,15 +41,23 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Practices.ServiceLocation">
+      <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="StructureMap">
+    <Reference Include="StructureMap, Version=3.1.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\structuremap.3.1.4.143\lib\net40\StructureMap.dll</HintPath>
     </Reference>
-    <Reference Include="StructureMap.Net4">
+    <Reference Include="StructureMap.Net4, Version=3.1.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\structuremap.3.1.4.143\lib\net40\StructureMap.Net4.dll</HintPath>
+    </Reference>
+    <Reference Include="StructureMap.Web">
+      <HintPath>..\packages\structuremap.web.3.1.0.133\lib\net40\StructureMap.Web.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
@@ -91,6 +99,9 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web.Services" />
     <Reference Include="System.EnterpriseServices" />
+    <Reference Include="WebActivatorEx">
+      <HintPath>..\packages\WebActivatorEx.2.0.6\lib\net40\WebActivatorEx.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Content\css\style.css" />
@@ -117,7 +128,13 @@
   <ItemGroup>
     <Compile Include="App_Start\FilterConfig.cs" />
     <Compile Include="App_Start\RouteConfig.cs" />
+    <Compile Include="App_Start\StructuremapMvc.cs" />
     <Compile Include="Controllers\HomeController.cs" />
+    <Compile Include="DependencyResolution\ControllerConvention.cs" />
+    <Compile Include="DependencyResolution\DefaultRegistry.cs" />
+    <Compile Include="DependencyResolution\IoC.cs" />
+    <Compile Include="DependencyResolution\StructureMapDependencyScope.cs" />
+    <Compile Include="DependencyResolution\StructureMapScopeModule.cs" />
     <Compile Include="Extensions\FeatureViewLocationRazorViewEngine.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>

--- a/src/UI/UI.csproj
+++ b/src/UI/UI.csproj
@@ -149,7 +149,12 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="App_Start\ViewEngineConfig.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj">
+      <Project>{F067D483-9E75-41E1-90EA-6B094F61CB61}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/src/UI/UI.csproj
+++ b/src/UI/UI.csproj
@@ -45,6 +45,12 @@
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
+    <Reference Include="StructureMap">
+      <HintPath>..\packages\structuremap.3.1.4.143\lib\net40\StructureMap.dll</HintPath>
+    </Reference>
+    <Reference Include="StructureMap.Net4">
+      <HintPath>..\packages\structuremap.3.1.4.143\lib\net40\StructureMap.Net4.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />

--- a/src/UI/UI.csproj
+++ b/src/UI/UI.csproj
@@ -139,6 +139,7 @@
     <Compile Include="DependencyResolution\StructureMapDependencyScope.cs" />
     <Compile Include="DependencyResolution\StructureMapScopeModule.cs" />
     <Compile Include="Extensions\FeatureViewLocationRazorViewEngine.cs" />
+    <Compile Include="Features\Library\AddEditHandler.cs" />
     <Compile Include="Features\Library\AddEditViewModel.cs" />
     <Compile Include="Features\Library\IndexHandler.cs" />
     <Compile Include="Features\Library\IndexViewModel.cs" />

--- a/src/UI/packages.config
+++ b/src/UI/packages.config
@@ -1,8 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="structuremap" version="3.1.4.143" targetFramework="net45" />
+  <package id="StructureMap.MVC5" version="3.1.1.134" targetFramework="net45" />
+  <package id="structuremap.web" version="3.1.0.133" targetFramework="net45" />
+  <package id="WebActivatorEx" version="2.0.6" targetFramework="net45" />
 </packages>

--- a/src/UI/packages.config
+++ b/src/UI/packages.config
@@ -4,4 +4,5 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+  <package id="structuremap" version="3.1.4.143" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
If you look through the history on `LibraryController`, you can see the progression of moving logic out of the controller (pretend the hard-coded list was instead a call to the database) into handlers, and moving persistence out of handlers into an `ISession`. (The `ISession` and its in-memory implementation will later be replaced with an ORM with issue #7.) 

The handlers get their `ISession` via dependency injection. The controller passes it along to them. The _controller_  gets the implementation of the `ISession` also by dependency injection, taking the `ISession` as an argument to the class's constructor and letting [StructureMap](https://github.com/structuremap/structuremap) fetch the implementation from its IoC container. (Many of the IoC infrastructure classes were created by the [StructureMap.MVC5 nuget package](http://www.nuget.org/packages/StructureMap.MVC5/).)

It would be nice for the tests to be able to take advantage of the IoC container, too. So this pull request introduces StructureMap into the test project as well. The Fixie convention now specifies instructions for test class lifecycle, telling Fixie to construct an instance of the test fixture class once per fixture, instead of with every test method inside the fixture. And the convention specifies that any class constructor arguments are to be filled by the IoC container. [AutoFixture](https://github.com/AutoFixture/AutoFixture) is still in charge of any test _method_ arguments.
